### PR TITLE
[상진] 백준 #2606, #1260, #11725, #1325, #2178

### DIFF
--- a/상진/Baekjoon/Graph-Traversal/BOJ11725.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ11725.py
@@ -1,0 +1,30 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+n = int(input())
+graph = [[] for _ in range(n+1)]
+parent = [0] * (n+1)
+
+for _ in range(n-1):
+    s,e = map(int, input().split())
+    graph[s].append(e)
+    graph[e].append(s)
+
+def bfs(start):
+    q = deque([start])
+    parent[start] = -1
+    while q:
+        v = q.popleft()
+        for i in graph[v]:
+            if not parent[i]:
+                parent[i] = v
+                q.append(i)
+
+bfs(1)
+
+for i in parent[2:]:
+    print(i)
+
+

--- a/상진/Baekjoon/Graph-Traversal/BOJ1260.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ1260.py
@@ -15,7 +15,6 @@ def dfs(start):
     print(start, end=' ')
     for i in range(1, n+1):
         if graph[start][i] == 1 and visitedDfs[i] == 0:
-            visitedDfs[i] = 1
             dfs(i)
 
 def bfs(start):

--- a/상진/Baekjoon/Graph-Traversal/BOJ1260.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ1260.py
@@ -1,0 +1,34 @@
+from collections import deque
+
+n, m, start = map(int, input().split())
+graph = [[0] * (n+1) for _ in range(n+1)]
+
+for _ in range(m):
+    x,y = map(int, input().split())
+    graph[x][y] = graph[y][x] = 1
+
+visitedDfs = [0 for _ in range(n+1)]
+visitedBfs = [0 for _ in range(n+1)]
+
+def dfs(start):
+    visitedDfs[start] = 1
+    print(start, end=' ')
+    for i in range(1, n+1):
+        if graph[start][i] == 1 and visitedDfs[i] == 0:
+            visitedDfs[i] = 1
+            dfs(i)
+
+def bfs(start):
+    print()
+    q = deque([start])
+    visitedBfs[start] = 1
+    while q:
+        v = q.popleft()
+        print(v, end=' ')
+        for i in range(1,n+1):
+            if graph[v][i] == 1 and visitedBfs[i] == 0:
+                q.append(i)
+                visitedBfs[i] = 1
+
+dfs(start)
+bfs(start)

--- a/상진/Baekjoon/Graph-Traversal/BOJ1260_AdjList.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ1260_AdjList.py
@@ -1,0 +1,37 @@
+from collections import deque
+
+n, m, start = map(int, input().split())
+graph = [[] * (n+1) for _ in range(n+1)]
+
+visitedDfs = [0 for _ in range(n+1)]
+visitedBfs = [0 for _ in range(n+1)]
+
+for _ in range(m):
+    x,y = map(int, input().split())
+    graph[x].append(y)
+    graph[y].append(x)
+
+for i in range(1,n+1):
+    graph[i].sort()
+
+def dfs(start):
+    visitedDfs[start] = 1
+    print(start, end=' ')
+    for i in graph[start]:
+        if not visitedDfs[i]:
+            dfs(i)
+
+def bfs(start):
+    print()
+    q = deque([start])
+    visitedBfs[start] = 1
+    while q:
+        v = q.popleft()
+        print(v, end=' ')
+        for i in graph[v]:
+            if not visitedBfs[i]:
+                q.append(i)
+                visitedBfs[i] = 1
+
+dfs(start)
+bfs(start)

--- a/상진/Baekjoon/Graph-Traversal/BOJ1325.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ1325.py
@@ -1,0 +1,34 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+node, edge = map(int, input().split())
+graph = [[] * (node+1) for _ in range(node+1)]
+answer = [0] * (node + 1)
+
+for i in range(edge):
+    s, e = map(int, input().split())
+    graph[e].append(s)
+
+def bfs(start):
+    cnt = 0
+    q = deque([start])
+    visited[start] = 1
+    while q:
+        v = q.popleft()
+        for next in graph[v]:
+            if not visited[next]:
+                q.append(next)
+                visited[next] = 1
+                cnt += 1
+    return cnt
+
+for i in range(1, node+1):
+    visited = [0] * (node + 1)
+    answer[i] = bfs(i)
+
+
+maxCount = max(answer)
+for i in range(1, node+1):
+    if answer[i] == maxCount:
+        print(i, end=" ")

--- a/상진/Baekjoon/Graph-Traversal/BOJ2178.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ2178.py
@@ -1,0 +1,25 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+dx = [-1,0,1,0]
+dy = [0,-1,0,1]
+
+n,m = map(int, input().split())
+graph = [list(map(int, input().rstrip())) for _ in range(n)]
+
+def bfs(startX, startY):
+    q = deque((startX, startY))
+    q.append((startX, startY))
+    while q:
+        x, y = q.popleft()
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+            if 0 <= nx < n and 0 <= ny < m:
+                if graph[nx][ny] == 1:
+                    graph[nx][ny] = graph[x][y] + 1
+                    q.append((nx, ny))
+
+bfs(0,0)
+print(graph[n-1][m-1])

--- a/상진/Baekjoon/Graph-Traversal/BOJ2178.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ2178.py
@@ -9,7 +9,7 @@ n,m = map(int, input().split())
 graph = [list(map(int, input().rstrip())) for _ in range(n)]
 
 def bfs(startX, startY):
-    q = deque((startX, startY))
+    q = deque()
     q.append((startX, startY))
     while q:
         x, y = q.popleft()

--- a/상진/Baekjoon/Graph-Traversal/BOJ2606.py
+++ b/상진/Baekjoon/Graph-Traversal/BOJ2606.py
@@ -1,0 +1,20 @@
+n = int(input())
+pairCount = int(input())
+
+graph = [[0] * n for _ in range(n)]
+visited = [0 for _ in range(n)]
+
+for i in range(pairCount):
+    x,y = map(int, input().split())
+    graph[x-1][y-1] = 1
+    graph[y-1][x-1] = 1
+
+def dfs(start):
+    visited[start] = 1
+    for i in range(n):
+        if graph[start][i] == 1 and visited[i] == 0:
+            dfs(i)
+
+dfs(0)
+print(sum(visited[1:]))
+


### PR DESCRIPTION
# [백준] 2606

### 변수

```python
graph = [[0] * n for _ in range(n)] # n*n 리스트
visited = [0 for _ in range(n)] # 방문했던 노드
```

### 풀이 과정

- 입력을 받으면서 양방향으로 입력받음
    
    ```python
    for i in range(pairCount):
        x,y = map(int, input().split())
        graph[x-1][y-1] = 1
        graph[y-1][x-1] = 1
    ```
    
- 재귀를 이용하여(DFS) 그래프의 값이 1이고, 아직 방문하지 않았다면 방문 처리를 진행함
    
    ```python
    def dfs(start):
        visited[start] = 1
        for i in range(n):
            if graph[start][i] == 1 and visited[i] == 0:
                dfs(i)
    ```
    
- 루트 노드가 1(idx = 0)이므로, 방문한 곳의 수(단, visited[0]은 제외)의 합이 정답
    
    ```python
    dfs(0)
    print(sum(visited[1:]))
    ```
    

### 회고

- 인접 행렬 / 인접 리스트에 대해 공부하자 ! (위 문제 풀이 방식은 인접 행렬)
    - **인접 행렬**
        
        ```python
        graph = [[0, 1, 1, 1], 
        	[1, 0, 1, 0], 
                 [1, 1, 0, 1],
                 [1, 0, 1, 0]]
        ```
        
        - 연결되었다면 가중치값을, 연결되지 않았다면 0을 입력
        - 무향 그래프일 경우, 대각선 대칭 / 유향 그래프일 경우, 대칭 X
        - 가중치가 존재하는 그래프의 경우, 1 대신 가중치 값을 이용 가능
    - **인접 리스트**
        
        ```python
        graph = [[1,2,3], 
        	[0,2], 
                 [0,1,3],
                 [0,2]]
        ```
        
        - 각각의 인덱스에 인접한 노드를 리스트 형태로 입력
    - **그럼 언제 인접 행렬을 쓰고 언제 인접 리스트를 사용해?**
        - 모든 연결 정보를 알아야 할 때 → 인접 리스트
        - 특정 노드의 연결 정보를 알아야 할 때 → 인접 행렬
        - N의 최대 크기가 클 때는, 인접 행렬 접근 시, N * N 만큼의 메모리가 낭비 될 수 있음 !

---

# [백준] 1260

### 변수

```python
n, m, start = map(int, input().split())
graph = [[0] * (n+1) for _ in range(n+1)] 

visitedDfs = [0 for _ in range(n+1)]
visitedBfs = [0 for _ in range(n+1)]
```

### 풀이 과정

1. **인접 행렬**
    - 인접 행렬 방식을 통한 그래프 초기화
        
        ```python
        for _ in range(m):
            x,y = map(int, input().split())
            graph[x][y] = graph[y][x] = 1
        ```
        
    - DFS
        - 재귀 이용하여 DFS 풀이
        - 반복문을 돌며, 해당 인덱스와 연결되어 있고 `(graph[start][i] == 1)`,
        - 아직 방문하지 않았다면 `(visitedDfs[i] == 0)` 재귀
            
            ```python
            def dfs(start):
                visitedDfs[start] = 1
                print(start, end=' ')
                for i in range(1, n+1):
                    if graph[start][i] == 1 and visitedDfs[i] == 0:
                        dfs(i)
            ```
            
    - BFS
        - deque를 이용하여 BFS 풀이
        - 처음 start를 deque에 넣고, `q.popleft()` 를 통해 탐색한 노드 출력
        - DFS와 동일한 방법으로, 조건을 만족할 때, deque에 해당 인덱스 추가
            
            ```python
            def bfs(start):
                print()
                q = deque([start])
                visitedBfs[start] = 1
                while q:
                    v = q.popleft()
                    print(v, end=' ')
                    for i in range(1,n+1):
                        if graph[v][i] == 1 and visitedBfs[i] == 0:
                            q.append(i)
                            visitedBfs[i] = 1
            ```
            
2. **인접 리스트** 
    - 인접 리스트 방식을 통한 그래프 초기화
        
        ```python
        for _ in range(m):
            x,y = map(int, input().split())
            graph[x].append(y)
            graph[y].append(x)
        ```
        
    - 주의 : 문제 조건에 방문 노드 번호가 작은 것부터 출력 → 각각의 리스트마다 정렬 필요
        
        ```python
        for i in range(1,n+1):
            graph[i].sort()
        ```
        
    - 이후 DFS/BFS는 인접 행렬과 거의 동일하나, 반복문 식만 조금 달라짐
        
        ```python
        def dfs(start):
            visitedDfs[start] = 1
            print(start, end=' ')
            for i in graph[start]: ## 인접 행렬과의 차이!
                if not visitedDfs[i]:
                    dfs(i)
        ```
        

### 회고

- 오랜만에 DFS / BFS 푸니까 기억이 가물가물했음
- 계속해서 문제를 풀어서 다시 감을 되찾도록 노력하자 !
- 특히 어떤 문제에서 어떤 DFS / BFS를 선택할 지, 또, 어떤 문제에서 인접 행렬 / 인접 리스트를 사용할 지 생각하고 그래프 문제에 접근하자 !

---

# [백준] 11725

### 변수

```python
n = int(input())
graph = [[] for _ in range(n+1)]
parent = [0] * (n+1) # Visited과 동일한 역할 but 부모 노드를 찾기 위해 이름 변경
```

### 풀이 과정

- 인접 리스트 방식을 통한 그래프 초기화
    - N이 최대 100,000이므로, 인접 행렬로 접근 시, 낭비가 심할 것 같아서 인접 리스트 사용
    
    ```python
    for _ in range(n-1):
        s,e = map(int, input().split())
        graph[s].append(e)
        graph[e].append(s)
    ```
    
- BFS를 이용하여 문제 접근
    - 리스트를 통해 해당 인덱스의 부모 노드를 parent[idx]에 저장
    
    ```python
    def bfs(start):
        q = deque([start])
        parent[start] = -1
        while q:
            v = q.popleft()
            for i in graph[v]:
                if not parent[i]:
                    parent[i] = v
                    q.append(i)
    
    bfs(1)
    ```
    

### 회고

- 기존의 방문 여부를 확인했던 visited 리스트를, 해당 노드의 부모 노드를 저장하는 방식으로도 사용할 수 있음

# [백준] 1325

### 변수

```python
import sys
from collections import deque # bfs 큐 
input = sys.stdin.readline # 최대한 시간 절약

node, edge = map(int, input().split())
graph = [[] * (node+1) for _ in range(node+1)]
answer = [0] * (node + 1) # answer[idx] = idx 노드가 해킹 가능한 최대 노드
```

### 풀이 과정

- 인접 리스트를 이용하여 그래프를 초기화
    - 단, 루트 노드를 설정하기 위해 양방향이 아닌, 단방향 + 역방향 기준으로 그래프 초기화
        
        ```python
        for i in range(edge):
            s, e = map(int, input().split())
            graph[e].append(s)
        ```
        
- 각각의 노드가 루트 노드일 때, 자식 노드의 수가 결국 해킹 가능한 노드의 전체 수이므로, 반복문을 돌며 루트 노드를 변경해가며 자식 노드의 수를 저장함
    
    ```python
    def bfs(start):
        cnt = 0
        q = deque([start])
        visited[start] = 1
        while q:
            v = q.popleft()
            for next in graph[v]:
                if not visited[next]:
                    q.append(next)
                    visited[next] = 1
                    cnt += 1
        return cnt
    
    for i in range(1, node+1):
        visited = [0] * (node + 1)
        answer[i] = bfs(i)
    ```
    
- 이후, answer 중 최대 값을 가지는 인덱스들을 순서대로 나열
    
    ```python
    maxCount = max(answer)
    for i in range(1, node+1):
        if answer[i] == maxCount:
            print(i, end=" ")
    ```
    

### 회고

- 양방향이 아닌 단방향, 그리고 역방향을 통해 루트 노드를 설정할 수 있음
- python3 가 아닌 pypy3으로만 제출해야 시간초과가 안나는 문제
- 그립습니다 c++..

---

# [백준] 2178

### 변수

```python
# 상좌하우 그래프 탐색
dx = [-1,0,1,0]
dy = [0,-1,0,1]

n,m = map(int, input().split())
graph = [list(map(int, input().rstrip())) for _ in range(n)]
```

### 풀이 과정

- BFS / 그래프를 탐색하며 1인 경우에만, 해당 값을 1 씩 증가 시킴
    
    ```python
    def bfs(startX, startY):
        q = deque()
        q.append((startX, startY))
        while q:
            x, y = q.popleft()
            for i in range(4):
                nx = x + dx[i]
                ny = y + dy[i]
                if 0 <= nx < n and 0 <= ny < m:
                    if graph[nx][ny] == 1:
                        graph[nx][ny] = graph[x][y] + 1
                        q.append((nx, ny))
    ```
    

### 회고

- deque 초기화를 조심하자 !
    - `q = deque((x,y))` 로 초기화시, `popleft()` 에서, `TypeError: cannot unpack non-iterable int object` 발생
    - `q = deque()` → `q.append((x,y))` 로 초기화할 것, 이는 deque를 사용하는 모든 문제에서 습관을 들이자 !