### PR TITLE
[상진, 19주차 - 유니온파인드] 백준 #20040, #1976, #1717, #4195, #10775

### DIFF
--- a/상진/Baekjoon/Union-Find/BOJ10775.py
+++ b/상진/Baekjoon/Union-Find/BOJ10775.py
@@ -1,0 +1,26 @@
+import sys
+sys.setrecursionlimit(10**5)
+input = sys.stdin.readline
+
+G = int(input())
+P = int(input())
+parent = [i for i in range(G+1)]
+ans = 0
+flag = True
+
+def find(x):
+    if x != parent[x]:
+        parent[x] = find(parent[x])
+    return parent[x]
+
+for _ in range(P):
+    d = int(input())
+    root_d = find(d)
+    if root_d != 0 and flag:
+        parent[root_d] = root_d - 1
+        ans += 1
+    else:
+        flag = False
+        break
+
+print(ans)

--- a/상진/Baekjoon/Union-Find/BOJ1717.py
+++ b/상진/Baekjoon/Union-Find/BOJ1717.py
@@ -1,0 +1,29 @@
+import sys
+input = sys.stdin.readline
+sys.setrecursionlimit(10**7)
+
+N,M = map(int, input().split())
+parent = [i for i in range(N+1)]
+
+def find(x):
+    if x != parent[x]:
+        parent[x] = find(parent[x])
+    return parent[x]
+
+def union(a,b):
+    a = find(a)
+    b = find(b)
+    if a <= b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+for i in range(M):
+    op,s,e = map(int, input().split())
+    if op == 0:
+        union(s,e)
+    else:
+        if find(s) == find(e):
+            print("YES")
+        else:
+            print("NO")

--- a/상진/Baekjoon/Union-Find/BOJ1976.py
+++ b/상진/Baekjoon/Union-Find/BOJ1976.py
@@ -1,0 +1,40 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+M = int(input())
+parent = [i for i in range(N)]
+
+def find(x):
+    if parent[x] != x:
+        parent[x] = find(parent[x])
+    return parent[x]
+
+def union(a,b):
+    a = find(a)
+    b = find(b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+g = []
+for i in range(N):
+    g.append(list(map(int, input().split())))
+    for j in range(N):
+        if g[i][j] == 1:
+            union(i,j)
+
+schedules = list(map(int, input().split()))
+p = parent[schedules[0]-1]
+
+ans = True
+for i in schedules:
+    if parent[i-1] != p:
+        ans = False
+        break
+
+if ans:
+    print("YES")
+else:
+    print("NO")

--- a/상진/Baekjoon/Union-Find/BOJ20040.py
+++ b/상진/Baekjoon/Union-Find/BOJ20040.py
@@ -1,0 +1,29 @@
+import sys
+input = sys.stdin.readline
+
+N,M = map(int, input().split())
+parent = [i for i in range(N)]
+
+def find(x):
+    if parent[x] != x:
+        parent[x] = find(parent[x])
+    return parent[x]
+
+def union(a,b):
+    a = find(a)
+    b = find(b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+ans = 0
+for i in range(1,M+1):
+    s,e = map(int, input().split())
+    if find(s) == find(e):
+        ans = i
+        break
+    else:
+        union(s,e)
+
+print(ans)

--- a/상진/Baekjoon/Union-Find/BOJ4195.py
+++ b/상진/Baekjoon/Union-Find/BOJ4195.py
@@ -1,0 +1,43 @@
+import sys
+input = sys.stdin.readline
+
+def find(x):
+    if x != parent[x]:
+        parent[x] = find(parent[x])
+    return parent[x]
+
+def union(a,b):
+    a = find(a)
+    b = find(b)
+
+    if a < b:
+        parent[b] = a
+        friends[a] += friends[b]
+    elif a > b:
+        parent[a] = b
+        friends[b] += friends[a]
+
+T = int(input())
+for _ in range(T):
+    N = int(input())
+    dic = dict()
+    parent = []
+    friends = []
+    idx = 0
+    for _ in range(N):
+        s,e = map(str, input().split())
+        if s not in dic.keys():
+            dic[s] = idx
+            parent.append(idx)
+            friends.append(1)
+            idx += 1
+        if e not in dic.keys():
+            dic[e] = idx
+            parent.append(idx)
+            friends.append(1)
+            idx += 1
+
+        union(dic[s], dic[e])
+        print(friends[find(dic[s])])
+
+


### PR DESCRIPTION
# [백준] 20040

### 변수

```python
import sys
input = sys.stdin.readline

N,M = map(int, input().split())
parent = [i for i in range(N)]
```

### 풀이 과정

- **`def find(x)`** : 해당 노드의 **루트노드**를 찾는 함수
    - **parent[x] = find(parent[x])** : **경로압축**
    
    ```python
    def find(x):
        if parent[x] != x:
            parent[x] = find(parent[x])
        return parent[x]
    ```
    
- **`def union(a,b)`** : a,b 노드를 합하는 함수
    - `find()` 를 통해 a,b의 루트노드를 구한 후, 하나의 루트노드를 향하도록 합친다.
    - 일반적으로 수가 작은 노드가 루트노드가 되도록 지정한다.
    
    ```python
    def union(a,b):
        a = find(a)
        b = find(b)
        if a < b:
            parent[b] = a
        else:
            parent[a] = b
    ```
    
- **`main`**
    - `s,e` 가 입력으로 들어왔을 때, 사이클이 존재하는 경우는, `s`의 루트노드와 `e`의 루트노드가 이미 동일한 경우이다.
        - 즉, `find(s) == find(e)` 인 경우에, 사이클이 발생한다.
    
    ```python
    ans = 0
    for i in range(1,M+1):
        s,e = map(int, input().split())
        if find(s) == find(e):
            ans = i
            break
        else:
            union(s,e)
    
    print(ans)
    ```
    

### 회고

- 경로압축을 통해 루트노드 찾는 과정을 `O(1)`으로 최적화할 수 있음을 알게 되었음 !
- (사이클이 존재 ↔ 두 노드의 루트노드가 이미 같은 경우) 임을 알게 되었던 문제

---

# [백준] 1976

### 변수

```python
import sys
input = sys.stdin.readline

N = int(input())
M = int(input())
parent = [i for i in range(N)]
```

### 풀이 과정

- **`유니온파인드`**
    
    ```python
    def find(x):
        if x != parent[x]:
            parent[x] = find(parent[x])
        return parent[x]
    
    def union(a,b):
        a = find(a)
        b = find(b)
        if a <= b:
            parent[b] = a
        else:
            parent[a] = b
    ```
    
- **`main`**
    - `g[i][j] == 1`인 경우, 연결되어 있는 상태를 의미하므로, `union(i,j)`를 통해 서로 합쳐준다.
    - `schedules` : 여행 계획
        - `p` : 처음 계획 여행 도시의 루트노드
    - `schedules`을 돌면서 해당 도시의 `parent`가 `p`가 아닌 경우, `False`로 바꾼다.
    
    ```python
    g = []
    for i in range(N):
        g.append(list(map(int, input().split())))
        for j in range(N):
            if g[i][j] == 1:
                union(i,j)
    
    schedules = list(map(int, input().split()))
    p = parent[schedules[0]-1]
    
    ans = True
    for i in schedules:
        if parent[i-1] != p:
            ans = False
            break
    
    if ans:
        print("YES")
    else:
        print("NO")
    ```
    

### 회고

- 유니온파인드를 통해 각 도시의 루트노드를 찾은 후, 여행 계획에 존재하는 모든 도시의 루트노드가 동일한 경우를 찾는 문제 !

---

# [백준] 1717

### 변수

```python
import sys
input = sys.stdin.readline
sys.setrecursionlimit(10**7) # 안하면 recursionError

N,M = map(int, input().split())
parent = [i for i in range(N+1)]
```

### 풀이 과정

- **`유니온파인드`**
    
    ```python
    def find(x):
        if x != parent[x]:
            parent[x] = find(parent[x])
        return parent[x]
    
    def union(a,b):
        a = find(a)
        b = find(b)
        if a <= b:
            parent[b] = a
        else:
            parent[a] = b
    ```
    
- **`main`**
    - `op`가 `0`인 경우, `union`을 호출한다.
    - `op`가 `1`인 경우, `find`를 통해 각각의 루트노드를 구한 후, 같으면 서로 같은 집합에 포함되어 있음을 의미하므로 `“YES”`를 출력한다.
    
    ```python
    for i in range(M):
        op,s,e = map(int, input().split())
        if op == 0:
            union(s,e)
        else:
            if find(s) == find(e):
                print("YES")
            else:
                print("NO")
    ```
    

### 회고

- 유니온파인드의 기본 문제 느낌 !

--- 

# [백준] 4195

### 변수

```python
import sys
input = sys.stdin.readline

T = int(input()) # 테스트케이스
```

### 풀이 과정

- **`유니온파인드`**
    - `union`
        - 예를 들어, A(1)와 B(2)가 친구인 경우,
            - `parent[1] = parent[2] = 1 (a < b)`
            - `friends[1] = friends[1] + friends[2]`
                - 1번 친구 네트워크에 2번 친구 네트워크에 속한 친구들을 더한다.
    
    ```python
    def find(x):
        if x != parent[x]:
            parent[x] = find(parent[x])
        return parent[x]
    
    def union(a,b):
        a = find(a)
        b = find(b)
    
        if a < b:
            parent[b] = a
            friends[a] += friends[b]
        elif a > b:
            parent[a] = b
            friends[b] += friends[a]
    ```
    
- **`main`**
    - `dic` : 입력된 순서대로 이름을 `idx`로 변경하기 위한 딕셔너리
    - `parent` : 루트노드를 저장하는 리스트
    - `friends` : 해당 노드의 친구 네트워크에 속한 수
        - 처음에는 모두 `1`로 저장한다.
    - 입력을 받은 후, `union`을 통해 각각의 `idx`를 통해 합연산을 진행한다.
        - `friends[s의 루트노드], friends[e의 루트노드]` 중, 한 곳에 친구 네트워크 수가 증가한다.
        - `find(dic[s]) == find(dic[e])` 이므로(둘 모두 하나의 루트노드를 가리키므로), 둘 중 하나의 루트노드를 구한 뒤, 해당 루트에 해당하는 `friends` 값을 출력한다.
    
    ```python
    
    for _ in range(T):
        N = int(input())
        dic = dict()
        parent = []
        friends = []
        idx = 0
        for _ in range(N):
            s,e = map(str, input().split())
            if s not in dic.keys():
                dic[s] = idx
                parent.append(idx)
                friends.append(1)
                idx += 1
            if e not in dic.keys():
                dic[e] = idx
                parent.append(idx)
                friends.append(1)
                idx += 1
    
            union(dic[s], dic[e])
            print(friends[find(dic[s])])
    ```
    

### 회고

- 처음에 `friends` 를  `friends = [1] * 100001` 와 같이 설정했더니 계속해서 `indexError` 가 발생하여 이를 해결하는데 굉장히 오래 걸렸다.🥲
- 해시와 연관되어 재밌었던 문제 !

---

# [백준] 10775

### 변수

```python
import sys
sys.setrecursionlimit(10**5) # RecursionError 방지
input = sys.stdin.readline

G = int(input()) # 게이트
P = int(input()) # 비행기
parent = [i for i in range(G+1)] # 초기 각 게이트의 부모는 자기 자신
ans = 0 
flag = True # flag 없이 break로 한다면 90% 대에서 틀렸습니다 발생
```

### 풀이 과정

- **`def find(x)`** : x 게이트의 부모 게이트를 찾는 함수
    
    ```python
    def find(x):
        if x != parent[x]:
            parent[x] = find(parent[x])
        return parent[x]
    ```
    
- **`main`**
    - `di` = `i` 비행기는 `1~d` 게이트 중 한 곳에 도킹 가능
    - `root_d` : 입력된 게이트의 루트 게이트
        - 본 문제에선, **현 비행기가 도킹 가능한 게이트** 느낌
        - `root_d`는 `1~G`까지만 가능함 → `root_d`가 `0`인 경우, `flag`를 `False`로 변경
    - `parent[root_d]` : `i` 비행기가 게이트 `d`에 도킹했을 때, **다음 비행기가 도킹 가능한 곳**
        
![image](https://github.com/Sangmin627/AlgoStudy2023/assets/97597051/71da48a2-d7de-4576-b2db-e99d913238b9)

   1. `d1 = 2` 인 경우, `root_d = 2`이므로 첫번째 비행기를 2번 게이트에 도킹 가능하다. 다음 비행기를 1번 게이트에 도킹하도록 `parent[2]`를 `1`로 변경한다.
   2. `d2 = 2` 인 경우, `root_d = 1`이므로 두번째 비행기가 1번 게이트에 도킹 가능하다. 다음 비행기를 0번 게이트에 도킹하도록 `parent[1]`를 `0`으로 변경한다.
   3. `d3 = 3` 인 경우, `root_d = 3` 이므로 세번째 비행기가 3번 게이트에 도킹 가능하다. 다음 비행기를 2번 게이트에 도킹하도록 `parent[3]`를 `2`로 변경한다.
   4. `d4 = 3` 인 경우, `root_d = 0` 이다. 이는, 해당 비행기가 도킹 가능한 게이트가 없음을 뜻하므로, `flag`를 `False`로 변경한다.

```python
for _ in range(P):
    d = int(input())
    root_d = find(d)
    if root_d != 0 and flag:
        parent[root_d] = root_d - 1
        ans += 1
    else:
        flag = False
        break

print(ans)
```
        

### 회고

- 어떻게 유니온파인드를 할 지 엄청나게 고민했던 문제.🥲
- `parent[root_d] = root_d - 1` 를 통해 다음 가능한 게이트를 가리키는 것을 찾기 굉장히 어려웠던 문제였다.